### PR TITLE
docs: Fix simple typo, accoding -> according

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RedisPAPA
 we use `redis info` to monitor the redis usage. PAPA means a father who is monitoring the redis.
->  accoding to the [redis doc](http://redis.io/commands/info), it is be recommanded to use `info` other than `monitor`.
+>  according to the [redis doc](http://redis.io/commands/info), it is be recommanded to use `info` other than `monitor`.
 
 ================
 
@@ -10,7 +10,7 @@ we use `redis info` to monitor the redis usage. PAPA means a father who is monit
 
 ## Let's start
 - `pip install -r requirements.txt`
-- check out the file `config.py` and make your own configure accoding to your redis servers.
+- check out the file `config.py` and make your own configure according to your redis servers.
 - the REDIS_SERVER should be formated like this `['ip:port:password', 'ip:port', .....]`
 - type this command `python run.py`, then you can watch it in `http://127.0.0.1:5000`
 - we recommand use this command to deploy: `gunicorn --worker-class socketio.sgunicorn.GeventSocketIOWorker run:app -b 0.0.0.0:5000`


### PR DESCRIPTION
There is a small typo in README.md.

Should read `according` rather than `accoding`.

